### PR TITLE
TweenScript推入缓存池时释放引用防止内存泄漏。

### DIFF
--- a/TweenScript.cs
+++ b/TweenScript.cs
@@ -486,10 +486,12 @@ namespace Tween
         /// </summary>
         public void OnInit()
         {
+            
         }
 
         public void OnPop()
         {
+            
         }
 
         /// <summary>
@@ -510,8 +512,19 @@ namespace Tween
             pathType = PathType.Line;
             pathPoints = null;
             currentStep = 0;
-            //            m_floatContral = null;
-            //toTransform = null;
+            // m_floatContral = null;
+            toTransform = null;
+            customMethodV3 = null;
+            customMethodV2 = null;
+            customMethodFloat = null;
+            m_rectRransform = null;
+            m_transform = null;
+            curve = null;
+            pathPoints = null;
+            pathWeith = null;
+            m_oldColor.Clear();
+            animCallBack = null;
+            animParameter = null;
         }
 
         #endregion


### PR DESCRIPTION
之前主要是animCallBack没有删除置空导致从缓存池拿出来之后还会执行animCallBack。既然如此就把相关的引用全部置空，防止了把不应该带进缓存池的字段值带进去，而且还避免内存泄漏。